### PR TITLE
fix: use logical_date fallback so queued DAG runs sort correctly

### DIFF
--- a/spade_executor_airflow/history_provider.py
+++ b/spade_executor_airflow/history_provider.py
@@ -64,17 +64,23 @@ class AirflowRunHistoryProvider(HistoryProvider):
                 elif run["state"] in ("running", "restarting"):
                     status = RunResult.Status.RUNNING
                     result = None
+
+                # Use start_date for created_at; fall back to logical_date (always present)
+                # so freshly triggered runs sort correctly even before they start.
+                sort_date_str = run.get("start_date") or run.get("logical_date")
+                created_at = (
+                    datetime.strptime(sort_date_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+                    if sort_date_str
+                    else None
+                )
+
                 process_run = RunResult(
                     process=process,
                     output=run,
                     status=status,
                     result=result,
-                    created_at=(
-                        datetime.strptime(run.get("start_date"), "%Y-%m-%dT%H:%M:%S.%f%z")
-                        if run.get("start_date")
-                        else None
-                    ),
-                    user_id=run["conf"].get("spade__user_id"),
+                    created_at=created_at,
+                    user_id=(run.get("conf") or {}).get("spade__user_id"),
                 )
                 ret.append(process_run)
         ret.sort(

--- a/spade_executor_airflow/history_provider.py
+++ b/spade_executor_airflow/history_provider.py
@@ -68,11 +68,7 @@ class AirflowRunHistoryProvider(HistoryProvider):
                 # Use start_date for created_at; fall back to logical_date (always present)
                 # so freshly triggered runs sort correctly even before they start.
                 sort_date_str = run.get("start_date") or run.get("logical_date")
-                created_at = (
-                    datetime.strptime(sort_date_str, "%Y-%m-%dT%H:%M:%S.%f%z")
-                    if sort_date_str
-                    else None
-                )
+                created_at = datetime.strptime(sort_date_str, "%Y-%m-%dT%H:%M:%S.%f%z") if sort_date_str else None
 
                 process_run = RunResult(
                     process=process,


### PR DESCRIPTION
This pull request improves the handling of run creation dates and user IDs in the `get_runs` method of `spade_executor_airflow/history_provider.py`. The main changes ensure that runs are sorted correctly even if they haven't started yet, and that missing configuration data is handled more robustly.

**Improvements to run creation date handling:**

* The `created_at` field now uses `start_date` if available, but falls back to `logical_date` (which is always present) to ensure that freshly triggered runs are sorted correctly even before they start.

**Robustness improvements:**

* The code now safely accesses the `spade__user_id` in the run configuration by handling cases where the `conf` field might be missing.