### PR TITLE
Fix DAG run sorting with logical_date fallback

### DIFF
--- a/spade_executor_airflow/history_provider.py
+++ b/spade_executor_airflow/history_provider.py
@@ -64,17 +64,19 @@ class AirflowRunHistoryProvider(HistoryProvider):
                 elif run["state"] in ("running", "restarting"):
                     status = RunResult.Status.RUNNING
                     result = None
+
+                # Use start_date for created_at; fall back to logical_date (always present)
+                # so freshly triggered runs sort correctly even before they start.
+                sort_date_str = run.get("start_date") or run.get("logical_date")
+                created_at = datetime.strptime(sort_date_str, "%Y-%m-%dT%H:%M:%S.%f%z") if sort_date_str else None
+
                 process_run = RunResult(
                     process=process,
                     output=run,
                     status=status,
                     result=result,
-                    created_at=(
-                        datetime.strptime(run.get("start_date"), "%Y-%m-%dT%H:%M:%S.%f%z")
-                        if run.get("start_date")
-                        else None
-                    ),
-                    user_id=run["conf"].get("spade__user_id"),
+                    created_at=created_at,
+                    user_id=(run.get("conf") or {}).get("spade__user_id"),
                 )
                 ret.append(process_run)
         ret.sort(

--- a/spade_executor_airflow/utils.py
+++ b/spade_executor_airflow/utils.py
@@ -23,10 +23,21 @@ def request_airflow_token(
     )
     if resp.status_code > 400:
         raise ValueError(f"Failed to get Airflow token: {resp.text}")
+
+    # Primary: extract token from JSON response {"access_token": "..."}
+    try:
+        token = resp.json().get("access_token")
+        if token:
+            return token
+    except ValueError:
+        pass
+
+    # Legacy fallback: extract token from cookies (to be removed)
     token = resp.cookies.get("_token")
-    if not token:
-        raise ValueError("Failed to get Airflow token: No token in response")
-    return token
+    if token:
+        return token
+
+    raise ValueError("Failed to get Airflow token: No token in response")
 
 
 def get_dag_runs(


### PR DESCRIPTION
This pull request improves the reliability and robustness of handling Airflow tokens and run metadata in the executor. The main changes ensure compatibility with both new and legacy Airflow authentication methods and improve the handling of run creation dates for better sorting.

**Airflow Token Handling:**
- Updated `request_airflow_token` in `spade_executor_airflow/utils.py` to first extract the token from the JSON response (`access_token`), with a fallback to the legacy cookie-based method. Raises a clear error if no token is found.

**Run Metadata Handling:**
- Improved `get_runs` in `spade_executor_airflow/history_provider.py` to use `start_date` as the primary creation date for runs, falling back to `logical_date` when necessary. This ensures correct sorting of freshly triggered runs, even before they start. Also made user ID extraction more robust by handling missing `conf`.