### PR TITLE
Fix DAG run sorting with logical_date fallback

### DIFF
--- a/spade_executor_airflow/history_provider.py
+++ b/spade_executor_airflow/history_provider.py
@@ -64,17 +64,19 @@ class AirflowRunHistoryProvider(HistoryProvider):
                 elif run["state"] in ("running", "restarting"):
                     status = RunResult.Status.RUNNING
                     result = None
+
+                # Use start_date for created_at; fall back to logical_date (always present)
+                # so freshly triggered runs sort correctly even before they start.
+                sort_date_str = run.get("start_date") or run.get("logical_date")
+                created_at = datetime.strptime(sort_date_str, "%Y-%m-%dT%H:%M:%S.%f%z") if sort_date_str else None
+
                 process_run = RunResult(
                     process=process,
                     output=run,
                     status=status,
                     result=result,
-                    created_at=(
-                        datetime.strptime(run.get("start_date"), "%Y-%m-%dT%H:%M:%S.%f%z")
-                        if run.get("start_date")
-                        else None
-                    ),
-                    user_id=run["conf"].get("spade__user_id"),
+                    created_at=created_at,
+                    user_id=(run.get("conf") or {}).get("spade__user_id"),
                 )
                 ret.append(process_run)
         ret.sort(

--- a/spade_executor_airflow/utils.py
+++ b/spade_executor_airflow/utils.py
@@ -23,10 +23,21 @@ def request_airflow_token(
     )
     if resp.status_code > 400:
         raise ValueError(f"Failed to get Airflow token: {resp.text}")
+
+    # Primary: extract token from JSON response {"access_token": "..."}
+    try:
+        token = resp.json().get("access_token")
+        if token:
+            return token
+    except ValueError:
+        pass
+
+    # Legacy fallback: extract token from cookies (to be removed)
     token = resp.cookies.get("_token")
-    if not token:
-        raise ValueError("Failed to get Airflow token: No token in response")
-    return token
+    if token:
+        return token
+
+    raise ValueError("Failed to get Airflow token: No token in response")
 
 
 def get_dag_runs(


### PR DESCRIPTION
This pull request improves how Airflow run history and authentication tokens are handled, making the code more robust and compatible with both current and legacy behaviors.

**Improvements to run history handling:**
- Use `start_date` as the primary `created_at` timestamp for `RunResult` objects, but fall back to `logical_date` if `start_date` is missing, ensuring that newly triggered runs are sorted correctly even before they start.
- Safely handle cases where `run["conf"]` may be missing by using a default empty dictionary when extracting the `user_id`.

**Authentication token retrieval improvements:**
- Prefer extracting the Airflow token from the JSON response (`access_token`), but fall back to the legacy method of extracting it from cookies if necessary. Raises a clear error if no token is found.